### PR TITLE
chore: store .wasm in ./dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 ^target/
 target
 /*.tgz
-/ast_reflection.wasm
+/dist/

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
     "reflection",
     "functionless"
   ],
-  "main": "ast_reflection.wasm",
+  "main": "dist/ast_reflection.wasm",
   "scripts": {
-    "build": "cargo build --release --target wasm32-wasi && cp target/wasm32-wasi/release/ast_reflection.wasm .",
+    "build": "rm -rf dist && mkdir dist && cargo build --release --target wasm32-wasi && cp target/wasm32-wasi/release/ast_reflection.wasm ./dist/",
     "release": "yarn build"
   },
   "files": [
-    "ast_reflection.wasm"
+    "dist/ast_reflection.wasm"
   ]
 }


### PR DESCRIPTION
GitHub workflows assume content to be in `./dist/`, so this change updates our build script to emit the .wasm bundle to `dist/ast_refletion.wasm`.