### PR TITLE
fix: support global references

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -385,6 +385,8 @@ impl ClosureDecorator {
 
             self.parse_var_declarator(var_decl.decls.first().unwrap())
           }
+          //  for (i in items)
+          //       ^
           VarDeclOrPat::Pat(pat) => self.parse_pat(pat),
         };
 
@@ -416,6 +418,8 @@ impl ClosureDecorator {
 
             self.parse_var_declarator(var_decl.decls.first().unwrap())
           }
+          // for (i of items)
+          //      ^
           VarDeclOrPat::Pat(pat) => self.parse_pat(pat),
         };
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,27 +1,29 @@
 use core::panic;
 
 use swc_common::DUMMY_SP;
+use swc_plugin::ast::*;
 use swc_plugin::utils::quote_ident;
-use swc_plugin::{
-  ast::*,
-};
 
-use crate::{closure_decorator::ClosureDecorator};
 use crate::ast::Node;
+use crate::closure_decorator::ClosureDecorator;
 
 const EMPTY_VEC: Vec<Box<Expr>> = vec![];
 
 impl ClosureDecorator {
-  pub fn parse_class_decl(&self, class_decl: &ClassDecl) -> Box<Expr> {
+  pub fn parse_class_decl(&mut self, class_decl: &ClassDecl) -> Box<Expr> {
     self.parse_class(Node::ClassDecl, Some(&class_decl.ident), &class_decl.class)
   }
 
-  pub fn parse_class_expr(&self, class_expr: &ClassExpr) -> Box<Expr> {
-    self.parse_class(Node::ClassExpr, class_expr.ident.as_ref(), &class_expr.class)
+  pub fn parse_class_expr(&mut self, class_expr: &ClassExpr) -> Box<Expr> {
+    self.parse_class(
+      Node::ClassExpr,
+      class_expr.ident.as_ref(),
+      &class_expr.class,
+    )
   }
 
-  fn parse_class(&self, kind: Node, ident: Option<&Ident>, class: &Class) -> Box<Expr> {
-    self.new_node(
+  fn parse_class(&mut self, kind: Node, ident: Option<&Ident>, class: &Class) -> Box<Expr> {
+    new_node(
       kind,
       vec![
         ident
@@ -49,23 +51,12 @@ impl ClosureDecorator {
     )
   }
 
-  pub fn parse_class_method(&self, method: &ClassMethod) -> Box<Expr> {
-    self.new_node(
-      Node::MethodDecl,
-      vec![
-        //
-        self.parse_prop_name(&method.key),
-        self.parse_params(&method.function.params),
-        self.parse_block(method.function.body.as_ref().unwrap()),
-      ],
-    )
-  }
+  pub fn parse_constructor(&mut self, ctor: &Constructor) -> Box<Expr> {
+    self.vm.bind_constructor_params(&ctor.params);
 
-  pub fn parse_constructor(&self, ctor: &Constructor) -> Box<Expr> {
-    self.new_node(
+    new_node(
       Node::ConstructorDecl,
       vec![
-        // params
         Box::new(Expr::Array(ArrayLit {
           elems: ctor
             .params
@@ -76,21 +67,15 @@ impl ClosureDecorator {
                 expr: match param {
                   ParamOrTsParamProp::Param(p) => self.parse_param(p),
                   ParamOrTsParamProp::TsParamProp(p) => match &p.param {
-                    TsParamPropParam::Ident(i) => self.new_node(
-                      Node::ParameterDecl,
-                      vec![
-                        //
-                        self.parse_ident(&i, false),
-                      ],
-                      
-                    ),
-                    TsParamPropParam::Assign(i) => self.new_node(
+                    TsParamPropParam::Ident(i) => {
+                      new_node(Node::ParameterDecl, vec![self.parse_ident(&i, false)])
+                    }
+                    TsParamPropParam::Assign(i) => new_node(
                       Node::ParameterDecl,
                       vec![
                         self.parse_pat(i.left.as_ref()),
                         self.parse_expr(i.right.as_ref()),
                       ],
-                      
                     ),
                   },
                 },
@@ -99,65 +84,141 @@ impl ClosureDecorator {
             .collect(),
           span: DUMMY_SP,
         })),
-        // block
         self.parse_block(ctor.body.as_ref().unwrap()),
       ],
     )
   }
 
-  pub fn parse_function_decl(&self, function: &FnDecl) -> Box<Expr> {
-    self.parse_function(Node::FunctionDecl, Some(&function.ident), &function.function)
+  pub fn parse_function_decl(&mut self, function: &FnDecl) -> Box<Expr> {
+    self.parse_function(
+      Node::FunctionDecl,
+      Some(&function.ident),
+      &function.function,
+    )
   }
 
-  pub fn parse_function_expr(&self, function: &FnExpr) -> Box<Expr> {
-    self.parse_function(Node::FunctionExpr, function.ident.as_ref(), &function.function)
+  pub fn parse_function_expr(&mut self, function: &FnExpr) -> Box<Expr> {
+    self.parse_function(
+      Node::FunctionExpr,
+      function.ident.as_ref(),
+      &function.function,
+    )
   }
 
-  fn parse_function(&self, kind: Node, name: Option<&Ident>, function: &Function) -> Box<Expr> {
-    self.new_node(
+  fn parse_function(&mut self, kind: Node, name: Option<&Ident>, function: &Function) -> Box<Expr> {
+    self.vm.bind_params(&function.params);
+
+    let params = self.parse_params(&function.params);
+
+    let body = function
+      .body
+      .as_ref()
+      .map(|b| self.parse_block(b))
+      .unwrap_or(undefined_expr());
+
+    new_node(
       kind,
       vec![
-        name.map(|ident| str(&ident.to_id().0)).unwrap_or(undefined_expr()),
-        self.parse_params(&function.params), 
-        function.body.as_ref().map(|b| self.parse_block(b)).unwrap_or(undefined_expr()),
-        if function.is_async { true_expr() } else { false_expr() },
-        if function.is_generator { true_expr() } else { false_expr() }
+        name
+          .map(|ident| str(&ident.to_id().0))
+          .unwrap_or(undefined_expr()),
+        params,
+        body,
+        if function.is_async {
+          true_expr()
+        } else {
+          false_expr()
+        },
+        if function.is_generator {
+          true_expr()
+        } else {
+          false_expr()
+        },
       ],
     )
   }
 
-  pub fn parse_arrow(&self, arrow: &ArrowExpr) -> Box<Expr> {
-    self.new_node(
+  pub fn parse_method(&mut self, method: &ClassMethod) -> Box<Expr> {
+    self.vm.enter();
+
+    self.vm.bind_params(&method.function.params);
+
+    let node = new_node(
+      Node::MethodDecl,
+      vec![
+        self.parse_prop_name(&method.key),
+        self.parse_params(&method.function.params),
+        self.parse_block(method.function.body.as_ref().unwrap()),
+      ],
+    );
+
+    self.vm.exit();
+
+    node
+  }
+
+  pub fn parse_private_method(&mut self, method: &PrivateMethod) -> Box<Expr> {
+    self.vm.enter();
+
+    self.vm.bind_params(&method.function.params);
+
+    let node = new_node(
+      Node::MethodDecl,
+      vec![
+        self.parse_private_name(&method.key),
+        self.parse_params(&method.function.params),
+        self.parse_block(method.function.body.as_ref().unwrap()),
+      ],
+    );
+
+    self.vm.exit();
+
+    node
+  }
+
+  pub fn parse_arrow(&mut self, arrow: &ArrowExpr) -> Box<Expr> {
+    self.vm.enter();
+
+    self.vm.bind_pats(&arrow.params);
+
+    let node = new_node(
       Node::ArrowFunctionExpr,
       vec![
-        self.parse_pats_as_params(&arrow.params), 
+        self.parse_pats_as_params(&arrow.params),
         match &arrow.body {
           BlockStmtOrExpr::BlockStmt(block) => self.parse_block(block),
-          BlockStmtOrExpr::Expr(expr) => self.new_node(Node::BlockStmt, vec![
-            Box::new(Expr::Array(ArrayLit {
-              elems: vec![
-                Some(ExprOrSpread {
-                  spread: None,
-                  expr: self.new_node(Node::ReturnStmt, vec![self.parse_expr(expr)])
-                }),
-              ],
+          BlockStmtOrExpr::Expr(expr) => new_node(
+            Node::BlockStmt,
+            vec![Box::new(Expr::Array(ArrayLit {
+              elems: vec![Some(ExprOrSpread {
+                spread: None,
+                expr: new_node(Node::ReturnStmt, vec![self.parse_expr(expr)]),
+              })],
               span: DUMMY_SP,
-            })) 
-          ]),
+            }))],
+          ),
         },
-        if arrow.is_async { true_expr() } else { false_expr() },
+        if arrow.is_async {
+          true_expr()
+        } else {
+          false_expr()
+        },
       ],
-    )
+    );
+
+    self.vm.exit();
+
+    node
   }
 
-  fn parse_pats_as_params(&self, pats: &[Pat]) -> Box<Expr> {
+  fn parse_pats_as_params(&mut self, pats: &[Pat]) -> Box<Expr> {
     Box::new(Expr::Array(ArrayLit {
       elems: pats
         .iter()
         .map(|pat| {
           Some(ExprOrSpread {
             spread: None,
-            expr: self.parse_pat_param(pat)
+            expr: self.parse_pat_param(pat),
           })
         })
         .collect(),
@@ -165,7 +226,7 @@ impl ClosureDecorator {
     }))
   }
 
-  fn parse_params(&self, params: &[Param]) -> Box<Expr> {
+  fn parse_params(&mut self, params: &[Param]) -> Box<Expr> {
     Box::new(Expr::Array(ArrayLit {
       elems: params
         .iter()
@@ -180,33 +241,32 @@ impl ClosureDecorator {
     }))
   }
 
-  fn parse_param(&self, param: &Param) -> Box<Expr> {
+  fn parse_param(&mut self, param: &Param) -> Box<Expr> {
     self.parse_pat_param(&param.pat)
   }
 
-  fn parse_pat_param(&self, pat: &Pat) -> Box<Expr> {
-    self.new_node(Node::ParameterDecl, match pat {
-      // foo(...a)
-      Pat::Rest(rest) => vec![
-        self.parse_pat(rest.arg.as_ref()),
-        undefined_expr(),
-        true_expr() 
-      ],
-      // foo(a = b)
-      Pat::Assign(assign) => vec![
-        self.parse_pat(assign.left.as_ref()),
-        self.parse_expr(assign.right.as_ref()),
-        false_expr()
-      ],
-      pat => vec![
-        self.parse_pat(pat),
-        undefined_expr(),
-        false_expr() 
-      ]
-    })
+  fn parse_pat_param(&mut self, pat: &Pat) -> Box<Expr> {
+    new_node(
+      Node::ParameterDecl,
+      match pat {
+        // foo(...a)
+        Pat::Rest(rest) => vec![
+          self.parse_pat(rest.arg.as_ref()),
+          undefined_expr(),
+          true_expr(),
+        ],
+        // foo(a = b)
+        Pat::Assign(assign) => vec![
+          self.parse_pat(assign.left.as_ref()),
+          self.parse_expr(assign.right.as_ref()),
+          false_expr(),
+        ],
+        pat => vec![self.parse_pat(pat), undefined_expr(), false_expr()],
+      },
+    )
   }
-  
-  fn parse_decl(&self, decl: &Decl) -> Box<Expr> {
+
+  fn parse_decl(&mut self, decl: &Decl) -> Box<Expr> {
     match decl {
       Decl::Class(class_decl) => self.parse_class_decl(class_decl),
       Decl::Fn(function) => self.parse_function_decl(function),
@@ -214,92 +274,171 @@ impl ClosureDecorator {
       Decl::TsInterface(_) => panic!("interface not supported"),
       Decl::TsModule(_) => panic!("module declarations not supported"),
       Decl::TsTypeAlias(_) => panic!("type alias not supported"),
-      Decl::Var(var_decl) => self.new_node(Node::VariableStmt, vec![self.parse_var_decl(var_decl)]),
+      Decl::Var(var_decl) => new_node(Node::VariableStmt, vec![self.parse_var_decl(var_decl)]),
     }
   }
 
-  fn parse_stmt(&self, stmt: &Stmt) -> Box<Expr> {
+  fn parse_stmt(&mut self, stmt: &Stmt) -> Box<Expr> {
     match stmt {
       Stmt::Block(block) => self.parse_block(block),
-      Stmt::Break(break_stmt) => self.new_node(Node::BreakStmt, vec![
-        break_stmt.label.as_ref().map(|label| self.parse_ident(label, false) ).unwrap_or(undefined_expr())
-      ]),
-      Stmt::Continue(continue_stmt) => self.new_node(Node::ContinueStmt, vec![
-        continue_stmt.label.as_ref().map(|label| self.parse_ident(label, false) ).unwrap_or(undefined_expr())
-      ]),
-      Stmt::Debugger(_debugger) => self.new_node(Node::DebuggerStmt, EMPTY_VEC),
+      Stmt::Break(break_stmt) => new_node(
+        Node::BreakStmt,
+        vec![break_stmt
+          .label
+          .as_ref()
+          .map(|label| self.parse_ident(label, false))
+          .unwrap_or(undefined_expr())],
+      ),
+      Stmt::Continue(continue_stmt) => new_node(
+        Node::ContinueStmt,
+        vec![continue_stmt
+          .label
+          .as_ref()
+          .map(|label| self.parse_ident(label, false))
+          .unwrap_or(undefined_expr())],
+      ),
+      Stmt::Debugger(_debugger) => new_node(Node::DebuggerStmt, EMPTY_VEC),
       Stmt::Decl(decl) => self.parse_decl(decl),
-      Stmt::DoWhile(do_while) => self.new_node(
+      Stmt::DoWhile(do_while) => new_node(
         Node::DoStmt,
         vec![
           // block
           match do_while.body.as_ref() {
             Stmt::Block(block) => self.parse_block(&block),
-            stmt => self.new_node(Node::BlockStmt, vec![
-              Box::new(Expr::Array(ArrayLit {
+            stmt => new_node(
+              Node::BlockStmt,
+              vec![Box::new(Expr::Array(ArrayLit {
                 elems: vec![Some(ExprOrSpread {
                   expr: self.parse_stmt(stmt),
                   spread: None,
                 })],
-                span: DUMMY_SP
-              }))
-            ])
+                span: DUMMY_SP,
+              }))],
+            ),
           },
           // condition
           self.parse_expr(do_while.test.as_ref()),
         ],
       ),
-      Stmt::Empty(_empty) => self.new_node(Node::EmptyStmt, EMPTY_VEC),
-      Stmt::Expr(expr_stmt) => self.new_node(
+      Stmt::Empty(_empty) => new_node(Node::EmptyStmt, EMPTY_VEC),
+      Stmt::Expr(expr_stmt) => new_node(
         Node::ExprStmt,
         vec![
           //expr
           self.parse_expr(expr_stmt.expr.as_ref()),
         ],
       ),
-      // TODO
-      Stmt::For(for_stmt) => self.new_node(
-        Node::ForStmt,
-        vec![
-          self.parse_stmt(for_stmt.body.as_ref()),
-          for_stmt
-            .init
-            .as_ref()
-            .map(|init| match init {
-              VarDeclOrExpr::Expr(expr) => self.parse_expr(expr.as_ref()),
-              VarDeclOrExpr::VarDecl(var) => self.parse_var_decl(&var),
-            })
-            .unwrap_or(undefined_expr()),
-          for_stmt.test.as_ref().map(|test| self.parse_expr(test)).unwrap_or(undefined_expr()),
-          for_stmt.update.as_ref().map(|test| self.parse_expr(test)).unwrap_or(undefined_expr())
-        ], 
-      ),
+      Stmt::For(for_stmt) => {
+        // create a unique scope for the contents for the variables declared in the for-loop's initializer
+        self.vm.enter();
+
+        let init = for_stmt
+          .init
+          .as_ref()
+          .map(|init| match init {
+            VarDeclOrExpr::Expr(expr) => self.parse_expr(expr.as_ref()),
+            VarDeclOrExpr::VarDecl(var) => {
+              // bind the for's variable declaration
+              // for (let i = 0; ..)
+              //          ^
+              self.vm.bind_var_decl(var);
+
+              self.parse_var_decl(&var)
+            }
+          })
+          .unwrap_or(undefined_expr());
+
+        let node = new_node(
+          Node::ForStmt,
+          vec![
+            self.parse_stmt(for_stmt.body.as_ref()),
+            init,
+            for_stmt
+              .test
+              .as_ref()
+              .map(|test| self.parse_expr(test))
+              .unwrap_or(undefined_expr()),
+            for_stmt
+              .update
+              .as_ref()
+              .map(|update| self.parse_expr(update))
+              .unwrap_or(undefined_expr()),
+          ],
+        );
+
+        // exit the for-loop's initializer scope
+        self.vm.exit();
+
+        node
+      }
       // for (const left in right)
-      Stmt::ForIn(for_in) => self.new_node(
-        Node::ForInStmt,
-        vec![
-          match &for_in.left {
-            VarDeclOrPat::VarDecl(var_decl) => self.parse_var_declarator(var_decl.decls.first().unwrap()),
-            VarDeclOrPat::Pat(pat) => self.parse_pat(pat),
-          },
-          self.parse_expr(&for_in.right),
-          self.parse_stmt(for_in.body.as_ref()),
-        ],
-      ),
+      Stmt::ForIn(for_in) => {
+        // create a unique scope for the contents for the variables declared in the for-in-loop's initializer
+        self.vm.enter();
+
+        let var = match &for_in.left {
+          VarDeclOrPat::VarDecl(var_decl) => {
+            // bind the for-in's variable declaration
+            // for (const k in ..)
+            //            ^
+            self.vm.bind_var_decl(var_decl);
+
+            self.parse_var_declarator(var_decl.decls.first().unwrap())
+          }
+          VarDeclOrPat::Pat(pat) => self.parse_pat(pat),
+        };
+
+        let node = new_node(
+          Node::ForInStmt,
+          vec![
+            var,
+            self.parse_expr(&for_in.right),
+            self.parse_stmt(for_in.body.as_ref()),
+          ],
+        );
+
+        // exit the for-in-loop's initializer scope
+        self.vm.exit();
+
+        node
+      }
       // for (const left of right)
-      Stmt::ForOf(for_of) => self.new_node(
-        Node::ForOfStmt,
-        vec![
-          match &for_of.left {
-            VarDeclOrPat::VarDecl(var_decl) => self.parse_var_declarator(var_decl.decls.first().unwrap()),
-            VarDeclOrPat::Pat(pat) => self.parse_pat(pat),
-          },
-          self.parse_expr(&for_of.right),
-          self.parse_stmt(for_of.body.as_ref()),
-          if for_of.await_token.is_some() { true_expr() } else { false_expr() }
-        ],
-      ),
-      Stmt::If(if_stmt) => self.new_node(
+      Stmt::ForOf(for_of) => {
+        // create a unique scope for the contents for the variables declared in the for-of-loop's initializer
+        self.vm.enter();
+
+        let var = match &for_of.left {
+          VarDeclOrPat::VarDecl(var_decl) => {
+            // bind the for-of's variable declaration
+            // for (const item of ..)
+            //             ^
+            self.vm.bind_var_decl(var_decl);
+
+            self.parse_var_declarator(var_decl.decls.first().unwrap())
+          }
+          VarDeclOrPat::Pat(pat) => self.parse_pat(pat),
+        };
+
+        let node = new_node(
+          Node::ForOfStmt,
+          vec![
+            var,
+            self.parse_expr(&for_of.right),
+            self.parse_stmt(for_of.body.as_ref()),
+            if for_of.await_token.is_some() {
+              true_expr()
+            } else {
+              false_expr()
+            },
+          ],
+        );
+
+        // exit the for-in-loop's initializer scope
+        self.vm.exit();
+
+        node
+      }
+      Stmt::If(if_stmt) => new_node(
         Node::IfStmt,
         vec![
           // when
@@ -316,14 +455,14 @@ impl ClosureDecorator {
       ),
       // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/label
       // for now, we just erase the label
-      Stmt::Labeled(labelled) => self.new_node(
+      Stmt::Labeled(labelled) => new_node(
         Node::LabelledStmt,
         vec![
           self.parse_ident(&labelled.label, false),
-          self.parse_stmt(&labelled.body)
+          self.parse_stmt(&labelled.body),
         ],
       ),
-      Stmt::Return(return_stmt) => self.new_node(
+      Stmt::Return(return_stmt) => new_node(
         Node::ReturnStmt,
         match return_stmt.arg.as_ref() {
           Some(arg) => vec![self.parse_expr(&arg)],
@@ -332,7 +471,7 @@ impl ClosureDecorator {
         },
       ),
       // TODO: support switch - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch
-      Stmt::Switch(switch) => self.new_node(
+      Stmt::Switch(switch) => new_node(
         Node::SwitchStmt,
         vec![
           self.parse_expr(&switch.discriminant),
@@ -345,21 +484,18 @@ impl ClosureDecorator {
               .map(|case| {
                 let stmts = Box::new(Expr::Array(ArrayLit {
                   span: DUMMY_SP,
-                  elems: case.cons.iter().map(|stmt| self.parse_stmt(stmt)).map(|expr| Some(ExprOrSpread {
-                    expr,
-                    spread: None
-                  })).collect()
+                  elems: case
+                    .cons
+                    .iter()
+                    .map(|stmt| self.parse_stmt(stmt))
+                    .map(|expr| Some(ExprOrSpread { expr, spread: None }))
+                    .collect(),
                 }));
 
                 Some(ExprOrSpread {
                   expr: match case.test.as_ref() {
-                    Some(test) => self.new_node(Node::CaseClause, vec![
-                      self.parse_expr(test),
-                      stmts
-                    ]),
-                    None => self.new_node(Node::DefaultClause, vec![
-                      stmts
-                    ]),
+                    Some(test) => new_node(Node::CaseClause, vec![self.parse_expr(test), stmts]),
+                    None => new_node(Node::DefaultClause, vec![stmts]),
                   },
                   spread: None,
                 })
@@ -368,32 +504,45 @@ impl ClosureDecorator {
           })),
         ],
       ),
-      Stmt::Throw(throw) => self.new_node(
-        Node::ThrowStmt,
-        vec![self.parse_expr(throw.arg.as_ref())],
-      ),
-      Stmt::Try(try_stmt) => self.new_node(
+      Stmt::Throw(throw) => new_node(Node::ThrowStmt, vec![self.parse_expr(throw.arg.as_ref())]),
+      Stmt::Try(try_stmt) => new_node(
         Node::TryStmt,
         vec![
           self.parse_block(&try_stmt.block),
           try_stmt
             .handler
             .as_ref()
-            .map(|catch| self.new_node(Node::CatchClause, vec![
-              match &catch.param {
-                Some(pat) => self.new_node(Node::VariableDecl, match pat {
-                  Pat::Assign(assign) => vec![
-                    self.parse_pat(&assign.left),
-                    self.parse_expr(&assign.right)
-                  ],
-                  _ => vec![
-                    self.parse_pat(pat)
-                  ]
-                }),
-                None => undefined_expr(),
-              },
-              self.parse_block(&catch.body)
-            ]))
+            .map(|catch| {
+              // create a scope for the catch block including the catch variable decl
+              self.vm.enter();
+
+              // if the catch has a variable decl, bind it to lexical scope
+              catch.param.iter().for_each(|pat| self.vm.bind_pat(pat));
+
+              let node = new_node(
+                Node::CatchClause,
+                vec![
+                  match &catch.param {
+                    Some(pat) => new_node(
+                      Node::VariableDecl,
+                      match pat {
+                        Pat::Assign(assign) => {
+                          vec![self.parse_pat(&assign.left), self.parse_expr(&assign.right)]
+                        }
+                        _ => vec![self.parse_pat(pat)],
+                      },
+                    ),
+                    None => undefined_expr(),
+                  },
+                  self.parse_block(&catch.body),
+                ],
+              );
+
+              // exit the catch's block
+              self.vm.exit();
+
+              node
+            })
             .unwrap_or(undefined_expr()),
           try_stmt
             .finalizer
@@ -402,26 +551,27 @@ impl ClosureDecorator {
             .unwrap_or(undefined_expr()),
         ],
       ),
-      Stmt::While(while_stmt) => self.new_node(
+      Stmt::While(while_stmt) => new_node(
         Node::WhileStmt,
         vec![
           self.parse_expr(while_stmt.test.as_ref()),
           match while_stmt.body.as_ref() {
             Stmt::Block(block) => self.parse_block(&block),
-            stmt => self.new_node(Node::BlockStmt, vec![
-              Box::new(Expr::Array(ArrayLit {
+            stmt => new_node(
+              Node::BlockStmt,
+              vec![Box::new(Expr::Array(ArrayLit {
                 elems: vec![Some(ExprOrSpread {
                   expr: self.parse_stmt(stmt),
                   spread: None,
                 })],
-                span: DUMMY_SP
-              }))
-            ])
+                span: DUMMY_SP,
+              }))],
+            ),
           },
         ],
       ),
       // TODO: support with https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/with
-      Stmt::With(with) => self.new_node(
+      Stmt::With(with) => new_node(
         Node::WithStmt,
         vec![
           self.parse_expr(with.obj.as_ref()),
@@ -431,33 +581,38 @@ impl ClosureDecorator {
     }
   }
 
-  fn parse_expr(&self, expr: &Expr) -> Box<Expr> {
+  fn parse_expr(&mut self, expr: &Expr) -> Box<Expr> {
     match expr {
-      Expr::Array(array) => self.new_node(
+      Expr::Array(array) => new_node(
         Node::ArrayLiteralExpr,
-        vec![
-          Box::new(Expr::Array(ArrayLit {
-            elems: array
-              .elems  
-              .iter()
-              .map(|element| Some(ExprOrSpread {
+        vec![Box::new(Expr::Array(ArrayLit {
+          elems: array
+            .elems
+            .iter()
+            .map(|element| {
+              Some(ExprOrSpread {
                 expr: match element {
-                  Some(e) => if e.spread.is_some() {
-                    self.new_node(Node::SpreadElementExpr, vec![self.parse_expr(e.expr.as_ref())])
-                  } else {
-                    self.parse_expr(e.expr.as_ref())
-                  },
-                  None => self.new_node(Node::OmittedExpr, vec![])
+                  Some(e) => {
+                    if e.spread.is_some() {
+                      new_node(
+                        Node::SpreadElementExpr,
+                        vec![self.parse_expr(e.expr.as_ref())],
+                      )
+                    } else {
+                      self.parse_expr(e.expr.as_ref())
+                    }
+                  }
+                  None => new_node(Node::OmittedExpr, vec![]),
                 },
-                spread: None
-              }))
-              .collect(),
-            span: DUMMY_SP
-          }))
-        ],
+                spread: None,
+              })
+            })
+            .collect(),
+          span: DUMMY_SP,
+        }))],
       ),
       Expr::Arrow(arrow) => self.parse_arrow(arrow),
-      Expr::Assign(assign) => self.new_node(
+      Expr::Assign(assign) => new_node(
         Node::BinaryExpr,
         vec![
           match &assign.left {
@@ -485,11 +640,8 @@ impl ClosureDecorator {
           self.parse_expr(assign.right.as_ref()),
         ],
       ),
-      Expr::Await(a_wait) => self.new_node(
-        Node::AwaitExpr,
-        vec![self.parse_expr(a_wait.arg.as_ref())],
-      ),
-      Expr::Bin(binary_op) => self.new_node(
+      Expr::Await(a_wait) => new_node(Node::AwaitExpr, vec![self.parse_expr(a_wait.arg.as_ref())]),
+      Expr::Bin(binary_op) => new_node(
         Node::BinaryExpr,
         vec![
           self.parse_expr(binary_op.left.as_ref()),
@@ -526,7 +678,7 @@ impl ClosureDecorator {
       Expr::Call(call) => self.parse_callee(&call.callee, &call.args, false),
       // TODO: extract properties from ts-parameters
       Expr::Class(class_expr) => self.parse_class_expr(class_expr),
-      Expr::Cond(cond) => self.new_node(
+      Expr::Cond(cond) => new_node(
         Node::ConditionExpr,
         vec![
           // when
@@ -539,18 +691,18 @@ impl ClosureDecorator {
       ),
       Expr::Fn(function) => self.parse_function_expr(&function),
       Expr::Ident(id) => self.parse_ident(id, true),
-      Expr::Invalid(_invalid) => self.new_error_node("Syntax Error"),
-      Expr::JSXElement(_jsx_element) => self.new_error_node("not sure what to do with JSXElement"),
-      Expr::JSXEmpty(_jsx_empty) => self.new_error_node("not sure what to do with JSXEmpty"),
-      Expr::JSXFragment(_jsx_fragment) => self.new_error_node("not sure what to do with JSXFragment"),
-      Expr::JSXMember(_jsx_member) => self.new_error_node("not sure what to do with JSXMember"),
+      Expr::Invalid(_invalid) => new_error_node("Syntax Error"),
+      Expr::JSXElement(_jsx_element) => new_error_node("not sure what to do with JSXElement"),
+      Expr::JSXEmpty(_jsx_empty) => new_error_node("not sure what to do with JSXEmpty"),
+      Expr::JSXFragment(_jsx_fragment) => new_error_node("not sure what to do with JSXFragment"),
+      Expr::JSXMember(_jsx_member) => new_error_node("not sure what to do with JSXMember"),
       Expr::JSXNamespacedName(_jsx_namespace_name) => {
-        self.new_error_node("not sure what to do with JSXNamespacedName")
+        new_error_node("not sure what to do with JSXNamespacedName")
       }
       Expr::Lit(literal) => match &literal {
         // not sure what type of node this is, will just error for now
-        Lit::JSXText(_) => self.new_error_node("not sure what to do with JSXText"),
-        _ => self.new_node(
+        Lit::JSXText(_) => new_error_node("not sure what to do with JSXText"),
+        _ => new_node(
           match literal {
             Lit::Bool(_) => Node::BooleanLiteralExpr,
             Lit::BigInt(_) => Node::BigIntExpr,
@@ -562,104 +714,102 @@ impl ClosureDecorator {
             Lit::JSXText(_text) => panic!("not sure what to do with JSXText"),
           },
           vec![Box::new(expr.clone())],
-          
         ),
       },
       Expr::Member(member) => self.parse_member(member, false),
-      Expr::MetaProp(_meta_prop) => self.new_error_node("MetaProp is not supported"),
-      Expr::New(call) => self.new_node(
+      Expr::MetaProp(_meta_prop) => new_error_node("MetaProp is not supported"),
+      Expr::New(call) => new_node(
         Node::NewExpr,
         vec![
           //
           self.parse_expr(&call.callee),
-          call.args.as_ref().map(|args| self.parse_call_args(args)).unwrap_or(empty_array_expr()) ,
+          call
+            .args
+            .as_ref()
+            .map(|args| self.parse_call_args(args))
+            .unwrap_or(empty_array_expr()),
         ],
       ),
-      Expr::Object(object) => self.new_node(
+      Expr::Object(object) => new_node(
         Node::ObjectLiteralExpr,
-        vec![
-          Box::new(Expr::Array(ArrayLit {
-            span: DUMMY_SP,
-            elems: object
-              .props
-              .iter()
-              .map(|prop| match prop {
-                PropOrSpread::Prop(prop) => match prop.as_ref() {
-                  // invalid according to SWC's docs on Prop::Assign
-                  Prop::Assign(_assign) => panic!("Invalid Syntax in Object Literal"),
-                  Prop::Getter(getter) => self.new_node(
-                    Node::GetAccessorDecl,
-                    vec![
-                      self.parse_prop_name(&getter.key),
-                      self.parse_block(&getter.body.as_ref().unwrap()),
-                    ],
-                    
-                  ),
-                  Prop::KeyValue(assign) => self.new_node(
-                    Node::PropAssignExpr,
-                    vec![
-                      self.parse_prop_name(&assign.key),
-                      self.parse_expr(assign.value.as_ref()),
-                    ],
-                    
-                  ),
-                  Prop::Method(method) => self.new_node(
-                    Node::MethodDecl,
-                    vec![
-                      //
-                      self.parse_prop_name(&method.key),
-                      self.parse_params(&method.function.params),
-                      self.parse_block(method.function.body.as_ref().unwrap()),
-                    ],
-                    
-                  ),
-                  Prop::Setter(setter) => self.new_node(
-                    Node::SetAccessorDecl,
-                    vec![
-                      self.parse_prop_name(&setter.key),
-                      self.parse_pat(&setter.param),
-                      self.parse_block(setter.body.as_ref().unwrap()),
-                    ],
-                    
-                  ),
-                  Prop::Shorthand(ident) => self.new_node(
-                    Node::PropAssignExpr,
-                    vec![self.parse_ident(ident, false), self.parse_ident(ident, true)],
-                  ),
-                },
-                PropOrSpread::Spread(spread) => self.new_node(
-                  Node::SpreadAssignExpr,
-                  vec![self.parse_expr(spread.expr.as_ref())],
-                  
+        vec![Box::new(Expr::Array(ArrayLit {
+          span: DUMMY_SP,
+          elems: object
+            .props
+            .iter()
+            .map(|prop| match prop {
+              PropOrSpread::Prop(prop) => match prop.as_ref() {
+                // invalid according to SWC's docs on Prop::Assign
+                Prop::Assign(_assign) => panic!("Invalid Syntax in Object Literal"),
+                Prop::Getter(getter) => new_node(
+                  Node::GetAccessorDecl,
+                  vec![
+                    self.parse_prop_name(&getter.key),
+                    self.parse_block(&getter.body.as_ref().unwrap()),
+                  ],
                 ),
-              })
-              .map(|prop| Some(ExprOrSpread {
+                Prop::KeyValue(assign) => new_node(
+                  Node::PropAssignExpr,
+                  vec![
+                    self.parse_prop_name(&assign.key),
+                    self.parse_expr(assign.value.as_ref()),
+                  ],
+                ),
+                Prop::Method(method) => new_node(
+                  Node::MethodDecl,
+                  vec![
+                    //
+                    self.parse_prop_name(&method.key),
+                    self.parse_params(&method.function.params),
+                    self.parse_block(method.function.body.as_ref().unwrap()),
+                  ],
+                ),
+                Prop::Setter(setter) => new_node(
+                  Node::SetAccessorDecl,
+                  vec![
+                    self.parse_prop_name(&setter.key),
+                    self.parse_pat(&setter.param),
+                    self.parse_block(setter.body.as_ref().unwrap()),
+                  ],
+                ),
+                Prop::Shorthand(ident) => new_node(
+                  Node::PropAssignExpr,
+                  vec![
+                    self.parse_ident(ident, false),
+                    self.parse_ident(ident, true),
+                  ],
+                ),
+              },
+              PropOrSpread::Spread(spread) => new_node(
+                Node::SpreadAssignExpr,
+                vec![self.parse_expr(spread.expr.as_ref())],
+              ),
+            })
+            .map(|prop| {
+              Some(ExprOrSpread {
                 expr: prop,
-                spread: None
-              }))
-              .collect(),
-          }))
-        ]
+                spread: None,
+              })
+            })
+            .collect(),
+        }))],
       ),
       Expr::OptChain(opt_chain) => match &opt_chain.base {
         OptChainBase::Call(call) => self.parse_call_expr(&call.callee, &call.args, true),
         OptChainBase::Member(member) => self.parse_member(&member, true),
       },
-      Expr::Paren(paren) => self.new_node(
+      Expr::Paren(paren) => new_node(
         Node::ParenthesizedExpr,
         vec![self.parse_expr(paren.expr.as_ref())],
       ),
-      Expr::PrivateName(private_name) => self.new_node(
-        Node::PrivateIdentifier,
-        vec![str(&format!("{}{}", "#", private_name.id.sym))],
-      ),
+      Expr::PrivateName(private_name) => self.parse_private_name(private_name),
       Expr::Seq(seq) => {
         if seq.exprs.len() < 2 {
           panic!("SequenceExpression with less than 2 expressions");
         }
         let first = self.parse_expr(seq.exprs.first().unwrap());
         seq.exprs.iter().skip(1).fold(first, |left, right| {
-          self.new_node(
+          new_node(
             Node::BinaryExpr,
             vec![
               //
@@ -667,30 +817,31 @@ impl ClosureDecorator {
               str(","),
               self.parse_expr(right),
             ],
-            
           )
         })
       }
-      Expr::SuperProp(super_prop) => self.new_node(
+      Expr::SuperProp(super_prop) => new_node(
         Node::PropAccessExpr,
         vec![
-          self.new_node(Node::SuperKeyword, vec![]),
+          new_node(Node::SuperKeyword, vec![]),
           match &super_prop.prop {
             SuperProp::Ident(ident) => self.parse_ident(ident, false),
-            SuperProp::Computed(comp) => self.new_node(
+            SuperProp::Computed(comp) => new_node(
               Node::ComputedPropertyNameExpr,
               vec![self.parse_expr(comp.expr.as_ref())],
-              
             ),
           },
         ],
       ),
       Expr::Tpl(tpl) => self.parse_template(tpl),
-      Expr::TaggedTpl(tagged_template) => self.new_node(Node::TaggedTemplateExpr, vec![
-        self.parse_expr(&tagged_template.tag),
-        self.parse_template(&tagged_template.tpl)
-      ]),
-      Expr::This(_this) => self.new_node(Node::ThisExpr, vec![Box::new(expr.clone())]),
+      Expr::TaggedTpl(tagged_template) => new_node(
+        Node::TaggedTemplateExpr,
+        vec![
+          self.parse_expr(&tagged_template.tag),
+          self.parse_template(&tagged_template.tpl),
+        ],
+      ),
+      Expr::This(_this) => new_node(Node::ThisExpr, vec![Box::new(expr.clone())]),
       // erase <expr> as <type> - take <expr> only
       Expr::TsAs(ts_as) => self.parse_expr(&ts_as.expr),
       // erase <expr> as const - take <expr>
@@ -702,7 +853,7 @@ impl ClosureDecorator {
       // <type>expr // erase <type> - take <expr> only
       Expr::TsTypeAssertion(as_type) => self.parse_expr(&as_type.expr),
       Expr::Unary(unary) => match unary.op {
-        UnaryOp::TypeOf | UnaryOp::Void | UnaryOp::Delete => self.new_node(
+        UnaryOp::TypeOf | UnaryOp::Void | UnaryOp::Delete => new_node(
           match unary.op {
             UnaryOp::TypeOf => Node::TypeOfExpr,
             UnaryOp::Void => Node::VoidExpr,
@@ -710,9 +861,8 @@ impl ClosureDecorator {
             _ => panic!("impossible"),
           },
           vec![self.parse_expr(unary.arg.as_ref())],
-          
         ),
-        _ => self.new_node(
+        _ => new_node(
           Node::UnaryExpr,
           vec![
             // op
@@ -728,10 +878,9 @@ impl ClosureDecorator {
             // expr
             self.parse_expr(unary.arg.as_ref()),
           ],
-          
         ),
       },
-      Expr::Update(update) => self.new_node(
+      Expr::Update(update) => new_node(
         if update.prefix {
           Node::UnaryExpr
         } else {
@@ -747,7 +896,7 @@ impl ClosureDecorator {
           self.parse_expr(update.arg.as_ref()),
         ],
       ),
-      Expr::Yield(yield_expr) => self.new_node(
+      Expr::Yield(yield_expr) => new_node(
         Node::YieldExpr,
         vec![
           yield_expr
@@ -765,45 +914,52 @@ impl ClosureDecorator {
   }
 
   fn parse_call_expr(
-    &self,
+    &mut self,
     expr: &Expr,
     args: &[ExprOrSpread],
     is_optional: bool,
   ) -> Box<Expr> {
-    self.new_node(
+    new_node(
       Node::CallExpr,
       vec![
         //
         self.parse_expr(expr),
         self.parse_call_args(args),
-        if is_optional { true_expr() } else { false_expr() }
-      ], 
+        if is_optional {
+          true_expr()
+        } else {
+          false_expr()
+        },
+      ],
     )
   }
 
   fn parse_callee(
-    &self,
+    &mut self,
     callee: &Callee,
     args: &[ExprOrSpread],
     is_optional: bool,
   ) -> Box<Expr> {
-    self.new_node(
+    new_node(
       Node::CallExpr,
       vec![
         //
         match callee {
-          Callee::Super(_) => self.new_node(Node::SuperKeyword, vec![]),
-          Callee::Import(_) => self.new_node(Node::ImportKeyword, vec![]),
+          Callee::Super(_) => new_node(Node::SuperKeyword, vec![]),
+          Callee::Import(_) => new_node(Node::ImportKeyword, vec![]),
           Callee::Expr(expr) => self.parse_expr(expr),
         },
         self.parse_call_args(args),
-        if is_optional { true_expr() } else { false_expr() }
+        if is_optional {
+          true_expr()
+        } else {
+          false_expr()
+        },
       ],
-      
     )
   }
 
-  fn parse_call_args(&self, args: &[ExprOrSpread]) -> Box<Expr> {
+  fn parse_call_args(&mut self, args: &[ExprOrSpread]) -> Box<Expr> {
     Box::new(Expr::Array(ArrayLit {
       span: DUMMY_SP,
       elems: args
@@ -812,13 +968,15 @@ impl ClosureDecorator {
           Some(ExprOrSpread {
             spread: None,
             expr: if arg.spread.is_some() {
-              self.new_node(Node::Argument, vec![
-                self.new_node(Node::SpreadElementExpr, vec![self.parse_expr(arg.expr.as_ref())])
-              ])
+              new_node(
+                Node::Argument,
+                vec![new_node(
+                  Node::SpreadElementExpr,
+                  vec![self.parse_expr(arg.expr.as_ref())],
+                )],
+              )
             } else {
-              self.new_node(Node::Argument, vec![
-                self.parse_expr(arg.expr.as_ref())
-              ])
+              new_node(Node::Argument, vec![self.parse_expr(arg.expr.as_ref())])
             },
           })
         })
@@ -826,21 +984,17 @@ impl ClosureDecorator {
     }))
   }
 
-  fn parse_member(&self, member: &MemberExpr, is_optional: bool) -> Box<Expr> {
-    self.new_node(
+  fn parse_member(&mut self, member: &MemberExpr, is_optional: bool) -> Box<Expr> {
+    new_node(
       match member.prop {
-        MemberProp::Computed(_) =>  Node::ElementAccessExpr,
-        _ =>  Node::PropAccessExpr
+        MemberProp::Computed(_) => Node::ElementAccessExpr,
+        _ => Node::PropAccessExpr,
       },
       vec![
         self.parse_expr(member.obj.as_ref()),
         match &member.prop {
           MemberProp::Ident(ident) => self.parse_ident(ident, false),
-          MemberProp::PrivateName(private_name) => self.new_node(
-            Node::PrivateIdentifier,
-            vec![str(&format!("#{}", private_name.id.sym))],
-            
-          ),
+          MemberProp::PrivateName(private_name) => self.parse_private_name(private_name),
           MemberProp::Computed(comp) => self.parse_expr(comp.expr.as_ref()),
         },
         if is_optional {
@@ -849,35 +1003,41 @@ impl ClosureDecorator {
           false_expr()
         },
       ],
-      
     )
   }
 
-  fn parse_block(&self, block: &BlockStmt) -> Box<Expr> {
-    self.new_node(
+  fn parse_block(&mut self, block: &BlockStmt) -> Box<Expr> {
+    self.vm.enter();
+
+    self.vm.bind_block(block);
+
+    let node = new_node(
       Node::BlockStmt,
-      vec![
-        Box::new(Expr::Array(ArrayLit {
-          elems: block
-            .stmts
-            .iter()
-            .map(|stmt| Some(ExprOrSpread {
+      vec![Box::new(Expr::Array(ArrayLit {
+        elems: block
+          .stmts
+          .iter()
+          .map(|stmt| {
+            Some(ExprOrSpread {
               expr: self.parse_stmt(stmt),
-              spread: None
-            }))
-            .collect(),
-          span: DUMMY_SP
-        }))
-      ],
-    )
+              spread: None,
+            })
+          })
+          .collect(),
+        span: DUMMY_SP,
+      }))],
+    );
+
+    self.vm.exit();
+
+    node
   }
 
-  fn parse_class_member(&self, member: &ClassMember) -> Option<Box<Expr>> {
+  fn parse_class_member(&mut self, member: &ClassMember) -> Option<Box<Expr>> {
     match member {
-      ClassMember::ClassProp(prop) => Some(self.new_node(
+      ClassMember::ClassProp(prop) => Some(new_node(
         Node::PropDecl,
         vec![
-          //
           self.parse_prop_name(&prop.key),
           Box::new(Expr::Lit(Lit::Bool(Bool {
             value: prop.is_static,
@@ -892,34 +1052,12 @@ impl ClosureDecorator {
       )),
       ClassMember::Constructor(ctor) => Some(self.parse_constructor(ctor)),
       ClassMember::Empty(_) => None,
-      ClassMember::Method(method) => Some(self.parse_class_method(method)),
-      ClassMember::PrivateMethod(method) => Some(self.new_node(
-        Node::MethodDecl,
-        vec![
-          //
-          self.new_node(
-            Node::PrivateIdentifier,
-            vec![
-              str(&format!("#{}", method.key.id.sym)),
-            ],
-            
-          ),
-          self.parse_params(&method.function.params),
-          self.parse_block(method.function.body.as_ref().unwrap()),
-        ],
-      )),
-      ClassMember::PrivateProp(prop) => Some(self.new_node(
+      ClassMember::Method(method) => Some(self.parse_method(method)),
+      ClassMember::PrivateMethod(method) => Some(self.parse_private_method(method)),
+      ClassMember::PrivateProp(prop) => Some(new_node(
         Node::PropDecl,
         vec![
-          //
-          self.new_node(
-            Node::PrivateIdentifier,
-            vec![
-              //
-              str(&format!("#{}", prop.key.id.sym)),
-            ],
-            
-          ),
+          self.parse_private_name(&prop.key),
           Box::new(Expr::Lit(Lit::Bool(Bool {
             value: prop.is_static,
             span: DUMMY_SP,
@@ -931,7 +1069,7 @@ impl ClosureDecorator {
             .unwrap_or(undefined_expr()),
         ],
       )),
-      ClassMember::StaticBlock(static_block) => Some(self.new_node(
+      ClassMember::StaticBlock(static_block) => Some(new_node(
         Node::ClassStaticBlockDecl,
         vec![self.parse_block(&static_block.body)],
       )),
@@ -939,204 +1077,231 @@ impl ClosureDecorator {
     }
   }
 
-  fn parse_prop_name(&self, prop: &PropName) -> Box<Expr> {
+  fn parse_prop_name(&mut self, prop: &PropName) -> Box<Expr> {
     match prop {
-      PropName::BigInt(i) => self.new_node(
+      PropName::BigInt(i) => new_node(
         Node::BigIntExpr,
         vec![Box::new(Expr::Lit(Lit::BigInt(i.clone())))],
       ),
-      PropName::Computed(c) => self.new_node(
+      PropName::Computed(c) => new_node(
         Node::ComputedPropertyNameExpr,
         vec![self.parse_expr(c.expr.as_ref())],
       ),
       PropName::Ident(i) => self.parse_ident(i, false),
-      PropName::Num(n) => self.new_node(
+      PropName::Num(n) => new_node(
         Node::NumberLiteralExpr,
         vec![Box::new(Expr::Lit(Lit::Num(n.clone())))],
       ),
-      PropName::Str(s) => self.new_node(
+      PropName::Str(s) => new_node(
         Node::StringLiteralExpr,
         vec![Box::new(Expr::Lit(Lit::Str(s.clone())))],
       ),
     }
   }
 
-  fn parse_var_decl(&self, var_decl: &VarDecl) -> Box<Expr> {
-    self.new_node(
+  fn parse_private_name(&mut self, name: &PrivateName) -> Box<Expr> {
+    new_node(
+      Node::PrivateIdentifier,
+      vec![str(&format!("#{}", name.id.sym))],
+    )
+  }
+
+  fn parse_var_decl(&mut self, var_decl: &VarDecl) -> Box<Expr> {
+    new_node(
       Node::VariableDeclList,
       vec![
         Box::new(Expr::Array(ArrayLit {
           elems: var_decl
             .decls
             .iter()
-            .map(|decl| Some(ExprOrSpread {
-              expr: self.parse_var_declarator(decl),
-              spread: None
-            }))
+            .map(|decl| {
+              Some(ExprOrSpread {
+                expr: self.parse_var_declarator(decl),
+                spread: None,
+              })
+            })
             .collect(),
-          span: DUMMY_SP
+          span: DUMMY_SP,
         })),
         num(match var_decl.kind {
           VarDeclKind::Const => 0,
           VarDeclKind::Let => 1,
           VarDeclKind::Var => 2,
-        })
-      ]
+        }),
+      ],
     )
   }
 
-  fn parse_var_declarator(&self, decl: &VarDeclarator) -> Box<Expr> {
-    self.new_node(Node::VariableDecl, vec![
-      self.parse_pat(&decl.name),
-      decl.init.as_ref().map(|init| self.parse_expr(init)).unwrap_or(undefined_expr())
-    ])
+  fn parse_var_declarator(&mut self, decl: &VarDeclarator) -> Box<Expr> {
+    new_node(
+      Node::VariableDecl,
+      vec![
+        self.parse_pat(&decl.name),
+        decl
+          .init
+          .as_ref()
+          .map(|init| self.parse_expr(init))
+          .unwrap_or(undefined_expr()),
+      ],
+    )
   }
 
-  fn parse_template(&self, tpl: &Tpl) -> Box<Expr> {
+  fn parse_template(&mut self, tpl: &Tpl) -> Box<Expr> {
     if tpl.exprs.len() == 0 {
-      self.new_node(Node::NoSubstitutionTemplateLiteral, vec![
-        str(&tpl.quasis.first().unwrap().raw)
-      ])
+      new_node(
+        Node::NoSubstitutionTemplateLiteral,
+        vec![str(&tpl.quasis.first().unwrap().raw)],
+      )
     } else {
-      self.new_node(Node::TemplateExpr, vec![
-        self.new_node(Node::TemplateHead, vec![
-          str(&tpl.quasis.first().unwrap().raw)
-        ]),
-        Box::new(Expr::Array(ArrayLit {
-          span:DUMMY_SP,
-          elems: tpl.exprs.iter().zip(tpl.quasis.iter().skip(1))
-          .map(|(expr, literal)| Some(ExprOrSpread {
-            expr: self.new_node(Node::TemplateSpan, vec![
-              // expr
-              self.parse_expr(expr),
-              // literal
-              self.new_node(
-                if literal.tail { Node::TemplateTail } else { Node::TemplateMiddle }, 
-                vec![str(&literal.raw)]
-              )
-            ]),
-            spread: None
-          })).collect()
-        }))
-      ])
+      new_node(
+        Node::TemplateExpr,
+        vec![
+          new_node(
+            Node::TemplateHead,
+            vec![str(&tpl.quasis.first().unwrap().raw)],
+          ),
+          Box::new(Expr::Array(ArrayLit {
+            span: DUMMY_SP,
+            elems: tpl
+              .exprs
+              .iter()
+              .zip(tpl.quasis.iter().skip(1))
+              .map(|(expr, literal)| {
+                Some(ExprOrSpread {
+                  expr: new_node(
+                    Node::TemplateSpan,
+                    vec![
+                      // expr
+                      self.parse_expr(expr),
+                      // literal
+                      new_node(
+                        if literal.tail {
+                          Node::TemplateTail
+                        } else {
+                          Node::TemplateMiddle
+                        },
+                        vec![str(&literal.raw)],
+                      ),
+                    ],
+                  ),
+                  spread: None,
+                })
+              })
+              .collect(),
+          })),
+        ],
+      )
     }
   }
-
 
   fn parse_ident(&self, ident: &Ident, is_ref: bool) -> Box<Expr> {
-    if is_ref && self.vm.is_id_visible(ident) {
+    if is_ref && &ident.sym == "undefined" {
+      new_node(Node::UndefinedLiteralExpr, vec![])
+    } else if is_ref && !self.vm.is_id_visible(ident) {
       // if this is a free variable, then create a new ReferenceExpr(() => ident)
-      self.new_node(Node::ReferenceExpr, vec![
-        str(&ident.sym),
-        Box::new(Expr::Arrow(ArrowExpr {
-          is_async: false,
-          is_generator: false,
-          params: vec![],
-          return_type: None,
-          span: DUMMY_SP,
-          type_params: None,
-          body: BlockStmtOrExpr::Expr(Box::new(Expr::Ident(ident.clone())))
-        })),
-        num(ident.to_id().1.as_u32()),
-        Box::new(Expr::Ident(quote_ident!("__filename")))
-      ])
-    } else if is_ref && &ident.sym == "undefined" {
-      self.new_node(
-        Node::UndefinedLiteralExpr,
-        vec![],
+      new_node(
+        Node::ReferenceExpr,
+        vec![
+          str(&ident.sym),
+          Box::new(Expr::Arrow(ArrowExpr {
+            is_async: false,
+            is_generator: false,
+            params: vec![],
+            return_type: None,
+            span: DUMMY_SP,
+            type_params: None,
+            body: BlockStmtOrExpr::Expr(Box::new(Expr::Ident(ident.clone()))),
+          })),
+          num(ident.to_id().1.as_u32()),
+          Box::new(Expr::Ident(quote_ident!("__filename"))),
+        ],
       )
     } else {
-      self.new_node(
-        Node::Identifier,
-        vec![str(&ident.sym)],
-      )
+      new_node(Node::Identifier, vec![str(&ident.sym)])
     }
   }
 
-  fn parse_pat(&self, pat: &Pat) -> Box<Expr> {
+  fn parse_pat(&mut self, pat: &Pat) -> Box<Expr> {
     match pat {
-      Pat::Array(array_binding) => self.new_node(
+      Pat::Array(array_binding) => new_node(
         Node::ArrayBinding,
-        vec![
-          Box::new(Expr::Array(ArrayLit {
-            span: DUMMY_SP,
-            elems: array_binding
-              .elems
-              .iter()
-              .map(|elem| Some(ExprOrSpread {
+        vec![Box::new(Expr::Array(ArrayLit {
+          span: DUMMY_SP,
+          elems: array_binding
+            .elems
+            .iter()
+            .map(|elem| {
+              Some(ExprOrSpread {
                 expr: match elem {
-                  Some(pat @ Pat::Ident(_)) => self.new_node(
-                    Node::BindingElem,
-                    vec![self.parse_pat(&pat), false_expr()],
-                  ),
-                  Some(pat)=> self.parse_pat(pat),
-                  None => self.new_node(Node::OmittedExpr, vec![]),
+                  Some(pat @ Pat::Ident(_)) => {
+                    new_node(Node::BindingElem, vec![self.parse_pat(&pat), false_expr()])
+                  }
+                  Some(pat) => self.parse_pat(pat),
+                  None => new_node(Node::OmittedExpr, vec![]),
                 },
-                spread: None
-              }))
-              .collect(),
-          }))
-        ]
+                spread: None,
+              })
+            })
+            .collect(),
+        }))],
       ),
-      Pat::Object(object_binding) => self.new_node(
+      Pat::Object(object_binding) => new_node(
         Node::ObjectBinding,
-        vec![
-          Box::new(Expr::Array(ArrayLit {
-            span: DUMMY_SP,
-            elems: object_binding
+        vec![Box::new(Expr::Array(ArrayLit {
+          span: DUMMY_SP,
+          elems: object_binding
             .props
             .iter()
-            .map(|prop| Some(ExprOrSpread {
-              spread: None,
-              expr: match prop {
-                ObjectPatProp::Assign(assign) => self.new_node(
-                  Node::BindingElem,
-                  match &assign.value {
-                    // {key: value}
-                    Some(value) => vec![
-                      self.parse_ident(&assign.key, true),
+            .map(|prop| {
+              Some(ExprOrSpread {
+                spread: None,
+                expr: match prop {
+                  ObjectPatProp::Assign(assign) => new_node(
+                    Node::BindingElem,
+                    match &assign.value {
+                      // {key: value}
+                      Some(value) => vec![
+                        self.parse_ident(&assign.key, true),
+                        false_expr(),
+                        undefined_expr(),
+                        self.parse_expr(value.as_ref()),
+                      ],
+                      // {key}
+                      None => vec![self.parse_ident(&assign.key, false), false_expr()],
+                    },
+                  ),
+                  // {key: value}
+                  ObjectPatProp::KeyValue(kv) => new_node(
+                    Node::BindingElem,
+                    vec![
+                      match kv.value.as_ref() {
+                        // if this is an assign pattern, e.g. {key = value}
+                        // then parse `key` as the `BindingElement.name` in FunctionlessAST
+                        Pat::Assign(assign) => self.parse_pat(assign.left.as_ref()),
+                        value => self.parse_pat(value),
+                      },
                       false_expr(),
-                      undefined_expr(),
-                      self.parse_expr(value.as_ref()),
+                      self.parse_prop_name(&kv.key),
+                      match kv.value.as_ref() {
+                        // if this is an assign patter, e.g. `{key = value}`
+                        // then parse `value` as the `BindingElement.initializer` in FunctionlessAST
+                        Pat::Assign(assign) => self.parse_expr(assign.right.as_ref()),
+                        _ => undefined_expr(),
+                      },
                     ],
-                    // {key}
-                    None => vec![self.parse_ident(&assign.key, false), false_expr()],
-                  },
-                  
-                ),
-                // {key: value}
-                ObjectPatProp::KeyValue(kv) => self.new_node(
-                  Node::BindingElem,
-                  vec![
-                    match kv.value.as_ref() {
-                      // if this is an assign pattern, e.g. {key = value}
-                      // then parse `key` as the `BindingElement.name` in FunctionlessAST
-                      Pat::Assign(assign) => self.parse_pat(assign.left.as_ref()),
-                      value => self.parse_pat(value),
-                    },
-                    false_expr(),
-                    self.parse_prop_name(&kv.key),
-                    match kv.value.as_ref() {
-                      // if this is an assign patter, e.g. `{key = value}`
-                      // then parse `value` as the `BindingElement.initializer` in FunctionlessAST
-                      Pat::Assign(assign) => self.parse_expr(assign.right.as_ref()),
-                      _ => undefined_expr(),
-                    },
-                  ],
-                  
-                ),
-                // { ...rest }
-                ObjectPatProp::Rest(rest) => self.new_node(
-                  Node::BindingElem,
-                  vec![self.parse_pat(&rest.arg), true_expr()],
-                ),
-              }
-            }))
-            .collect()
-          }))
-        ],
+                  ),
+                  // { ...rest }
+                  ObjectPatProp::Rest(rest) => new_node(
+                    Node::BindingElem,
+                    vec![self.parse_pat(&rest.arg), true_expr()],
+                  ),
+                },
+              })
+            })
+            .collect(),
+        }))],
       ),
-      Pat::Assign(assign) => self.new_node(
+      Pat::Assign(assign) => new_node(
         Node::BindingElem,
         vec![
           self.parse_pat(assign.left.as_ref()),
@@ -1147,40 +1312,40 @@ impl ClosureDecorator {
       ),
       Pat::Expr(expr) => self.parse_expr(expr),
       Pat::Ident(ident) => self.parse_ident(ident, false),
-      Pat::Invalid(_invalid) => self.new_error_node("Invalid Node"),
-      Pat::Rest(rest) => self.new_node(Node::BindingElem, vec![self.parse_pat(rest.arg.as_ref()), true_expr()]),
+      Pat::Invalid(_invalid) => new_error_node("Invalid Node"),
+      Pat::Rest(rest) => new_node(
+        Node::BindingElem,
+        vec![self.parse_pat(rest.arg.as_ref()), true_expr()],
+      ),
     }
   }
+}
 
-  fn new_node(&self, kind: Node, args: Vec<Box<Expr>>) -> Box<Expr> {
-    let mut elems: Vec<Option<ExprOrSpread>> = vec![Some(ExprOrSpread {
-      expr: Box::new(Expr::Lit(Lit::Num(Number {
-        raw: None,
-        span: DUMMY_SP,
-        value: kind as u32 as f64
-      }))),
-      spread: None
-    })];
+fn new_node(kind: Node, args: Vec<Box<Expr>>) -> Box<Expr> {
+  let mut elems: Vec<Option<ExprOrSpread>> = vec![Some(ExprOrSpread {
+    expr: Box::new(Expr::Lit(Lit::Num(Number {
+      raw: None,
+      span: DUMMY_SP,
+      value: kind as u32 as f64,
+    }))),
+    spread: None,
+  })];
 
-    args
-    .iter()
-    .for_each(|arg| elems.push(Some(ExprOrSpread {
+  args.iter().for_each(|arg| {
+    elems.push(Some(ExprOrSpread {
       expr: arg.to_owned(),
       spread: None,
-    })));
-
-    Box::new(Expr::Array(ArrayLit {
-      span: DUMMY_SP,
-      elems: elems
     }))
-  }
+  });
 
-  fn new_error_node(&self, message: &str) -> Box<Expr> {
-    self.new_node(
-      Node::Err,
-      vec![str(message)],
-    )
-  }
+  Box::new(Expr::Array(ArrayLit {
+    span: DUMMY_SP,
+    elems: elems,
+  }))
+}
+
+fn new_error_node(message: &str) -> Box<Expr> {
+  new_node(Node::Err, vec![str(message)])
 }
 
 // fn arr(elems: Vec<Box<Expr>>) -> Box<Expr> {
@@ -1205,7 +1370,7 @@ fn num(i: u32) -> Box<Expr> {
   Box::new(Expr::Lit(Lit::Num(Number {
     raw: None,
     span: DUMMY_SP,
-    value: i as u32 as f64
+    value: i as u32 as f64,
   })))
 }
 
@@ -1234,6 +1399,6 @@ fn undefined_expr() -> Box<Expr> {
 fn empty_array_expr() -> Box<Expr> {
   Box::new(Expr::Array(ArrayLit {
     elems: vec![],
-    span: DUMMY_SP
+    span: DUMMY_SP,
   }))
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -386,7 +386,7 @@ impl ClosureDecorator {
             self.parse_var_declarator(var_decl.decls.first().unwrap())
           }
           //  for (i in items)
-          //       ^
+          //       ^ not a new name, so no binding created
           VarDeclOrPat::Pat(pat) => self.parse_pat(pat),
         };
 
@@ -419,7 +419,7 @@ impl ClosureDecorator {
             self.parse_var_declarator(var_decl.decls.first().unwrap())
           }
           // for (i of items)
-          //      ^
+          //      ^ not a new name, so no binding created
           VarDeclOrPat::Pat(pat) => self.parse_pat(pat),
         };
 


### PR DESCRIPTION
Fixes #5 

Our free-variable logic is backwards. We track all variables seen prior to a closure and use that to detect a free variable (an identifier that exists in the map), but this doesn't work for global references that have no declaration within a module.

This change reverses the logic to detect free variables when an identifier doesn't exist in a map of all names declared within the closure itself.