### PR TITLE
fix: register export function declarations

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -153,7 +153,12 @@
     },
     "test": {
       "name": "test",
-      "description": "Run tests"
+      "description": "Run tests",
+      "steps": [
+        {
+          "exec": "sh ./tests/functionless.sh"
+        }
+      ]
     },
     "unbump": {
       "name": "unbump",

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -41,4 +41,6 @@ project.compileTask.exec(
   "cargo build --release --target wasm32-wasi && cp target/wasm32-wasi/release/ast_reflection.wasm ."
 );
 
+project.testTask.exec("sh ./tests/functionless.sh");
+
 project.synth();

--- a/tests/functionless.sh
+++ b/tests/functionless.sh
@@ -1,0 +1,22 @@
+yarn link
+
+ROOT_DIR=$(pwd)
+TEST_DIR="${ROOT_DIR}/.test"
+
+mkdir -p ${TEST_DIR}
+
+clean_up() {
+  rm -rf ${TEST_DIR}
+}
+
+trap clean_up EXIT
+
+cd .test
+
+git clone --depth 1 git@github.com:functionless/functionless.git
+
+cd functionless
+yarn
+yarn link @functionless/ast-reflection
+yarn compile
+yarn test:fast

--- a/tests/functionless.sh
+++ b/tests/functionless.sh
@@ -13,9 +13,10 @@ trap clean_up EXIT
 
 cd .test
 
-git clone --depth 1 git@github.com:functionless/functionless.git
+git clone --depth 1 https://github.com/functionless/functionless.git
 
 cd functionless
+
 yarn
 yarn link @functionless/ast-reflection
 yarn compile


### PR DESCRIPTION
Fixes #13 

- [x] Detects and registers all `function declaration`s
- [x] Add a test script to checkout and run test:fast on functionless using the new version of ast-reflection 