### PR TITLE
feat: intercept Proxy instantiations

### DIFF
--- a/src/closure_decorator.rs
+++ b/src/closure_decorator.rs
@@ -314,9 +314,9 @@ impl VisitMut for ClosureDecorator {
             type_args: None,
             args: args,
           });
-
-          expr.visit_mut_children_with(self);
         }
+
+        expr.visit_mut_children_with(self);
       }
       _ => {
         expr.visit_mut_children_with(self);


### PR DESCRIPTION
This change intercepts syntax that looks like a Proxy instantiation.

```ts
new Proxy(...args)
```
This syntactic pattern is transformed into the following intercepted code.
```ts
function proxy_8269d1a8(clss, ...args) {
    const proxy = new clss(...args);
    if (global_8269d1a8.util.types.isProxy(proxy)) {
        const proxyMap = global_8269d1a8[global_8269d1a8.Symbol.for("functionless:Proxies")] = global_8269d1a8[global_8269d1a8.Symbol.for("functionless:Proxies")] ?? new global_8269d1a8.WeakMap;
        proxyMap.set(proxy, args);
    }
    return proxy;
}
const proxy = proxy_8269d1a8(Proxy, {
    a: 1
}, {
    b: 1
});
```

It safely adds all Proxies into a WeakMap that contains the Proxy arguments. To retrieve the arguments for a Proxy, look it up on `globalThis[Symbol.for("functionless:Proxies")].get(proxy)`.

This can be used by closure serialization to re-create Proxies.