### PR TITLE
fix: use VariableDecList in ForOf and ForIn

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -548,7 +548,7 @@ impl<'a> ClosureDecorator<'a> {
             //            ^
             self.vm.bind_var_decl(var_decl);
 
-            self.parse_var_declarator(var_decl.decls.first().unwrap())
+            self.parse_var_decl(var_decl)
           }
           //  for (i in items)
           //       ^ not a new name, so no binding created
@@ -583,7 +583,7 @@ impl<'a> ClosureDecorator<'a> {
             //             ^
             self.vm.bind_var_decl(var_decl);
 
-            self.parse_var_declarator(var_decl.decls.first().unwrap())
+            self.parse_var_decl(var_decl)
           }
           // for (i of items)
           //      ^ not a new name, so no binding created


### PR DESCRIPTION
Parse the `initializer` field in ForOfStmt and ForInStmt as a `VariableDeclList` instead of `VariableDecl` for ES conformance.

Related: https://github.com/functionless/functionless/pull/494

BREAKING CHANGE: `initializer` field in ForOfStmt and ForInStmt is now a `VariableDeclList` 