### PR TITLE
fix: parse setter parameter as ParameterDecl

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1032,7 +1032,7 @@ impl<'a> ClosureDecorator<'a> {
                   &setter.span,
                   vec![
                     self.parse_prop_name(&setter.key),
-                    self.parse_pat(&setter.param),
+                    self.parse_pat_param(&setter.param, None),
                     self.parse_block(setter.body.as_ref().unwrap()),
                     false_expr(),
                     undefined_expr(),

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1027,9 +1027,11 @@ impl<'a> ClosureDecorator<'a> {
                   &concat_span(&get_prop_name_span(&method.key), &method.function.span),
                 ),
                 Prop::Setter(setter) => {
+                  self.vm.enter();
+
                   self.vm.bind_pat(&setter.param);
 
-                  new_node(
+                  let node = new_node(
                     self.source_map,
                     Node::SetAccessorDecl,
                     &setter.span,
@@ -1040,7 +1042,11 @@ impl<'a> ClosureDecorator<'a> {
                       false_expr(),
                       undefined_expr(),
                     ],
-                  )
+                  );
+
+                  self.vm.exit();
+
+                  node
                 }
                 Prop::Shorthand(ident) => new_node(
                   self.source_map,

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1026,18 +1026,22 @@ impl<'a> ClosureDecorator<'a> {
                   None,
                   &concat_span(&get_prop_name_span(&method.key), &method.function.span),
                 ),
-                Prop::Setter(setter) => new_node(
-                  self.source_map,
-                  Node::SetAccessorDecl,
-                  &setter.span,
-                  vec![
-                    self.parse_prop_name(&setter.key),
-                    self.parse_pat_param(&setter.param, None),
-                    self.parse_block(setter.body.as_ref().unwrap()),
-                    false_expr(),
-                    undefined_expr(),
-                  ],
-                ),
+                Prop::Setter(setter) => {
+                  self.vm.bind_pat(&setter.param);
+
+                  new_node(
+                    self.source_map,
+                    Node::SetAccessorDecl,
+                    &setter.span,
+                    vec![
+                      self.parse_prop_name(&setter.key),
+                      self.parse_pat_param(&setter.param, None),
+                      self.parse_block(setter.body.as_ref().unwrap()),
+                      false_expr(),
+                      undefined_expr(),
+                    ],
+                  )
+                }
                 Prop::Shorthand(ident) => new_node(
                   self.source_map,
                   Node::PropAssignExpr,


### PR DESCRIPTION
We were not parsing the SetAccessorDecl's parameter as a ParameterDecl.