### PR TITLE
feat: refactor register, bind, and proxy to use s_expressions 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+### Pre-req
+
+* Rust - `curl https://sh.rustup.rs -sSf | sh`
+
+### Once
+
+```
+> yarn default
+> rustup target add wasm32-wasi
+```
+
+### Each Change
+
+```
+> yarn compile
+```

--- a/src/closure_decorator.rs
+++ b/src/closure_decorator.rs
@@ -20,14 +20,14 @@ use crate::virtual_machine::VirtualMachine;
  * These can be used by downstream programs to discover and manipulate the injects
  * functionless assignment sequences.
  */
-// (REGISTER,stash=func,stash[]=ast,stash)
-const REGISTER_FLAG: &str = "REGISTER_8269d1a8";
-// (REGISTER_REF,stash[]=ast)
-const REGISTER_REF_FLAG: &str = "REGISTER_REF_8269d1a8";
-// // (BIND, ...)
-const BIND_FLAG: &str = "BIND_8269d1a8";
-// // (PROXY, ...)
-const PROXY_FLAG: &str = "PROXY_8269d1a8";
+// (stash=REGISTER,stash=func,stash[]=ast,stash)
+const REGISTER_FLAG: &str = "REGISTER";
+// (stash=REGISTER_REF,stash[]=ast)
+const REGISTER_REF_FLAG: &str = "REGISTER_REF";
+// // (stash=BIND, ...)
+const BIND_FLAG: &str = "BIND";
+// // (stash=PROXY, ...)
+const PROXY_FLAG: &str = "PROXY";
 
 const GLOBAL_THIS_NAME: &str = "global_8269d1a8";
 

--- a/src/closure_decorator.rs
+++ b/src/closure_decorator.rs
@@ -26,9 +26,9 @@ use crate::virtual_machine::VirtualMachine;
 const REGISTER_FLAG: &str = "REGISTER_8269d1a8";
 // (REGISTER_REF,stash[]=ast)
 const REGISTER_REF_FLAG: &str = "REGISTER_REF_8269d1a8";
-// // (BIND, ... todo)
+// // (BIND, ...)
 const BIND_FLAG: &str = "BIND_8269d1a8";
-// // (PROXY, ... todo)
+// // (PROXY, ...)
 const PROXY_FLAG: &str = "PROXY_8269d1a8";
 
 const GLOBAL_THIS_NAME: &str = "global_8269d1a8";
@@ -828,10 +828,10 @@ impl<'a> ClosureDecorator<'a> {
   /**
    * ("PROXY",
    *    stash={ args }, // ensure the args are only evaluated once
-   *    stash={ proxy: new clss(...stash.args), ...stash },
+   *    stash={ proxy: new clss(...stash.args), ...stash }, // create the proxy
    *    globalThis.util.types.isProxy(stash.proxy) && (
    *       globalThis.proxies = globalThis.proxies ?? new globalThis.WeakMap(),
-   *       proxyMap.set(proxy, args)
+   *       proxyMap.set(stash.proxy, stash.args)
    *    ),
    *    proxy
    * )


### PR DESCRIPTION
Depends on: https://github.com/functionless/functionless/pull/520

```ts
("REGISTER", stash = () => {}, stash[Symbol.from(functionless::AST)] = ast, stash)

("REGISTER_REF", stash=REGISTER_REF,x[Symbol.for(AST)]=ast)

("BIND",
   stash={ args: args, self: this, func: func },
   stash={ f: stash.func.bind(stash.self, ...stash.args), ...stash },
   typeof stash.f === "function" && (
       stash.f[Symbol.for("functionless:BoundThis")] = stash.self,
       stash.f[Symbol.for("functionless:BoundArgs")] = stash.args,
       stash.f[Symbol.for("functionless:TargetFunction")] = stash.func
   ),
   stash
)

("PROXY",
   stash={ args }, // ensure the args are only evaluated once
   stash={ proxy: new clss(...stash.args), ...stash }, // create the proxy
   globalThis.util.types.isProxy(stash.proxy) && (
      globalThis.proxies = globalThis.proxies ?? new globalThis.WeakMap(),
      proxyMap.set(stash.proxy, stash.args)
   ),
   proxy
)
```