### PR TITLE
fix: patterns can be references

### DIFF
--- a/src/virtual_machine.rs
+++ b/src/virtual_machine.rs
@@ -23,6 +23,10 @@ pub type Stack = Vec<Names>;
 
 impl VirtualMachine {
   pub fn is_id_visible(&self, ident: &Ident) -> bool {
+    // println!(
+    //   "is id visible {}",
+    //   serde_json::to_string(&ident.to_id()).unwrap_or_else(|_| ident.sym.to_string())
+    // );
     self.lookup_id(ident.to_id())
   }
 
@@ -84,6 +88,10 @@ impl VirtualMachine {
   }
 
   pub fn bind_id(&mut self, id: Id) {
+    // println!(
+    //   "register id {}",
+    //   serde_json::to_string(&id).unwrap_or_else(|_| id.0.to_string())
+    // );
     let names = self.stack.last_mut().expect("stack underflow");
     *names = names.update(id);
   }

--- a/src/virtual_machine.rs
+++ b/src/virtual_machine.rs
@@ -23,10 +23,6 @@ pub type Stack = Vec<Names>;
 
 impl VirtualMachine {
   pub fn is_id_visible(&self, ident: &Ident) -> bool {
-    // println!(
-    //   "is id visible {}",
-    //   serde_json::to_string(&ident.to_id()).unwrap_or_else(|_| ident.sym.to_string())
-    // );
     self.lookup_id(ident.to_id())
   }
 
@@ -88,10 +84,6 @@ impl VirtualMachine {
   }
 
   pub fn bind_id(&mut self, id: Id) {
-    // println!(
-    //   "register id {}",
-    //   serde_json::to_string(&id).unwrap_or_else(|_| id.0.to_string())
-    // );
     let names = self.stack.last_mut().expect("stack underflow");
     *names = names.update(id);
   }


### PR DESCRIPTION
Patterns were always considered to be declarations, when they can be references.

This caused an issue when using assignment in functionless as the x was considered a declaration, but was actually a reference and the reference to `x` would not be updated if the declaration was updated.

```ts
let x = 1;
x = 1; // pat(ident) = numberliteral
```

```ts
let x = 1;
x += 1; // ident += numberliteral 
```